### PR TITLE
remove deprecated usage of Attr.nodeName and use Attr.name instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,28 @@ To run the tests yourself, you will need Java and Ant installed and then do the 
 4. Run the server:
 
     <pre>../server/server.sh web.xml</pre>
-    
+
 5. Visit [http://localhost:8888/](http://localhost:8888/) in your browser.
 6. Select the markup language from the drop-down list box and hit the 'Test' button.  The system will run the test cases rather silently unless you look at the console.  Eventually, it will output a table of the status of all the test cases.
 
 
+## NPM package
 
+An [NPM package](https://www.npmjs.com/package/green-turtle) is in
+development. Right now it only exports a path to the build script so
+that it can be run within [jsdom](https://github.com/tmpvar/jsdom).
+
+
+```
+var greenTurtleScript = require('green-turtle')
+  , jsdom = require('jsdom');
+
+jsdom.env({
+  file: 'test.html',
+  scripts: [greenTurtleScript],
+  done: function(err, window) {
+    if (err) console.error(err);
+    console.log(window.document.data.graph.toString());
+  }
+});
+```

--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+var path = require('path');
+
+module.exports = path.join(__dirname, 'build', 'RDFa.js');

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "green-turtle",
+  "version": "0.0.0",
+  "description": "An RDFa 1.1 implementation in JavaScript for browsers.",
+  "main": "index.js",
+  "scripts": {
+    "prepublish": "ant"
+  },
+  "keywords": [
+    "RDFa"
+  ]
+}

--- a/src/RDFaProcessor.js
+++ b/src/RDFaProcessor.js
@@ -29,8 +29,8 @@ RDFaProcessor.prototype.newBlankNode = function() {
    return "_:"+this.blankCounter;
 }
 
-RDFaProcessor.XMLLiteralURI = "http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral"; 
-RDFaProcessor.HTMLLiteralURI = "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML"; 
+RDFaProcessor.XMLLiteralURI = "http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral";
+RDFaProcessor.HTMLLiteralURI = "http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML";
 RDFaProcessor.PlainLiteralURI = "http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral";
 RDFaProcessor.objectURI = "http://www.w3.org/1999/02/22-rdf-syntax-ns#object";
 RDFaProcessor.typeURI = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
@@ -240,10 +240,10 @@ RDFaProcessor.prototype.setHTMLContext = function() {
 RDFaProcessor.prototype.setXHTMLContext = function() {
 
    this.setInitialContext();
-   
+
    this.inXHTMLMode = true;
    this.inHTMLMode = false;
-   
+
    this.langAttributes = [ { namespaceURI: "http://www.w3.org/XML/1998/namespace", localName: "lang" },
                            { namespaceURI: null, localName: "lang" }];
 
@@ -327,7 +327,7 @@ RDFaProcessor.prototype.process = function(node,options) {
       this.setContext(node);
    } else if (node.parentNode.nodeType==Node.DOCUMENT_NODE) {
       this.setContext(node);
-   } 
+   }
    var queue = [];
    // Fix for Firefox that includes the hash in the base URI
    var removeHash = function(baseURI) {
@@ -410,12 +410,12 @@ RDFaProcessor.prototype.process = function(node,options) {
       for (var i=0; i<current.attributes.length; i++) {
          var att = current.attributes[i];
          //if (att.namespaceURI=="http://www.w3.org/2000/xmlns/") {
-         if (att.nodeName.charAt(0)=="x" && att.nodeName.indexOf("xmlns:")==0) {
+         if (att.name.charAt(0)=="x" && att.name.indexOf("xmlns:")==0) {
             if (!prefixesCopied) {
                prefixes = this.copyMappings(prefixes);
                prefixesCopied = true;
             }
-            var prefix = att.nodeName.substring(6);
+            var prefix = att.name.substring(6);
             // TODO: resolve relative?
             var ref = RDFaProcessor.trim(att.value);
             prefixes[prefix] = this.target.baseURI ? this.target.baseURI.resolve(ref) : ref;
@@ -458,7 +458,7 @@ RDFaProcessor.prototype.process = function(node,options) {
       var resourceAtt = current.getAttributeNode("resource");
       var hrefAtt = current.getAttributeNode("href");
       var inlistAtt = current.getAttributeNode("inlist");
-      
+
       var relAttPredicates = [];
       if (relAtt) {
          var values = this.tokenize(relAtt.value);
@@ -479,7 +479,7 @@ RDFaProcessor.prototype.process = function(node,options) {
             }
          }
       }
-      
+
       // Section 3.1, bullet 7
       if (this.inHTMLMode && (relAtt!=null || revAtt!=null) && propertyAtt!=null) {
          if (relAttPredicates.length==0) {
@@ -509,7 +509,7 @@ RDFaProcessor.prototype.process = function(node,options) {
          if (resourceAtt) {
             currentObjectResource = this.parseSafeCURIEOrCURIEOrURI(resourceAtt.value,prefixes,base);
          }
-         
+
          if (!currentObjectResource) {
             if (hrefAtt) {
                currentObjectResource = this.resolveAndNormalize(base,encodeURI(hrefAtt.value));
@@ -609,7 +609,7 @@ RDFaProcessor.prototype.process = function(node,options) {
             this.newSubjectOrigin(current,id);
          }
       }
-      
+
       // Sequence Step 7: generate type triple
       if (typedResource) {
          var values = this.tokenize(typeofAtt.value);
@@ -681,7 +681,7 @@ RDFaProcessor.prototype.process = function(node,options) {
       // Step 11: Current property values
       if (propertyAtt) {
          var datatype = null;
-         var content = null; 
+         var content = null;
          if (datatypeAtt) {
             datatype = datatypeAtt.value=="" ? RDFaProcessor.PlainLiteralURI : this.parseTermOrCURIEOrAbsURI(datatypeAtt.value,vocabulary,context.terms,prefixes,base);
             if (datetimeAtt && !contentAtt) {
@@ -803,7 +803,7 @@ RDFaProcessor.prototype.process = function(node,options) {
          }
       }
    }
-   
+
    if (this.inHTMLMode) {
       this.copyProperties();
    }
@@ -830,4 +830,3 @@ RDFaProcessor.prototype.push = function(parent,subject) {
       vocabulary: parent ? parent.vocabulary : this.vocabulary
    };
 };
-


### PR DESCRIPTION
Hello,

Attr.nodeName is now deprecated (see https://developer.mozilla.org/en-US/docs/Web/API/Attr#Deprecated_properties_and_methods)

In practice, I needed that so that I can run green-turtle in node.js through [jsdom](https://github.com/tmpvar/jsdom) (A JavaScript implementation of the DOM, for use with node.js).

With that patch the following seem to work fine with JSDOM

```
jsdom.env({
  file: 'test.html',
  scripts: ['/path/to/green-turtle/build/RDFa.js'],
  done: function(err, window) {
    if (err) console.error(err);
    console.log(window.document.data.graph.toString());
  }
});
```

There are probably other little things to patch so that things work properly but I can keep appending them to this PR if you are OK to merge those.

Otherwise, it would be nice to give green-turtle a package.json and make it available to NPM. Some refactoring would have to happen to restructure the files in their own modules but a lot of the code could be used in Node.js (or as standalone functions).
In particular it would be nice to use something like https://github.com/scienceai/get-dom to provide a DOM.
I am happy to help if that's something that you are willing to merge.

Thanks!
